### PR TITLE
Scale3d() flickers in Chrome 16 when the element is partially outside of the viewport

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -100,7 +100,11 @@
       if (!(value instanceof Transform))
         value = new Transform(value);
 
-      if (support.transform == 'WebkitTransform')
+     	// We've seen the 3D version of Scale() not work in Chrome when the element being scaled extends outside of
+			// the viewport.  Thus, we're forcing Chrome to not use the 3d transforms as well.  Not sure if translate is
+			// affectede, but not risking it.  Detection code from http://davidwalsh.name/detecting-google-chrome-javascript
+			var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
+      if (support.transform == 'WebkitTransform' && !is_chrome)
         elem.style[support.transform] = value.toString(true);
       else
         elem.style[support.transform] = value.toString();


### PR DESCRIPTION
We've seen the 3D version of Scale() not work in Chrome when the element being scaled extends outside of the viewport. I've posted a video showing the behavior using the http://ricostacruz.com/jquery.transit/ demo site.

http://www.youtube.com/watch?v=1I2xsVJQrIA&feature=youtu.be

This small change checks for Chrome and tells it to use non 3D transforms if it's found.  I could see you wanting to refactor my tweak to something more elegant, but I mainly wanted to make you aware of this issue we discovered.
