### PR TITLE
queue property did not work as expected

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -455,7 +455,7 @@
       delete properties.complete;
     }
 
-    if (properties.queue) {
+    if (properties.queue !== undefined) {
       queue = properties.queue;
       delete properties.queue;
     }


### PR DESCRIPTION
I wanted to use queue property and this was never applied correctly.

I required to avoid using the queue, because the following case did not work as expected.

``` javascript
          //////// First Transtion
          var transition = ( isHorizontal ) ?  {rotateY: rotate}:{rotateX: rotate};
          me.$().transition(transition, duration, easing);

         /// Clean up properties
         var css = {
            '-webkit-transform-style':''
            , '-webkit-transition-property': ''
            , '-webkit-transition-duration': ''
            , '-webkit-transition-timing-function': ''
            , '-webkit-transition-delay': ''
            , '-webkit-transform': ''
          };          
          me.$().css(css);

          ////// Second transition won't work without queue property set to false
          var transition = ( isHorizontal ) ?  {rotateY: rotate, queue: false}:{rotateX: rotate, queue: false};
          me.$().transition(transition, duration, easing);
```
