### PR TITLE
Fix bug with undefined next function

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -509,7 +509,7 @@
       var fn = function(next) {
         self.css(properties);
         if (callback) { callback(); }
-        next();
+        if (typeof next === 'function') { next(); }
       };
 
       callOrQueue(self, queue, fn);


### PR DESCRIPTION
... can be raised by 374 line by calling `fn();`
