### PR TITLE
No queue transition IE fix

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -517,7 +517,7 @@
       var fn = function(next) {
         self.css(properties);
         if (callback) { callback.apply(self); }
-        next();
+        if (next) { next(); }
       };
 
       callOrQueue(self, queue, fn);


### PR DESCRIPTION
Fixed a bug crashing the script in IE when running it with queue set to false.
