### PR TITLE
Add AMD support to jQuery.Transit architecture

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -111,7 +111,7 @@
   //     $("#hello").css('transform');
   //     //=> { rotate: '90deg' }
   //
-  $.cssHooks.transform = {
+  $.cssHooks["transit:transform"] = {
     // The getter returns a `Transform` object.
     get: function(elem) {
       return $(elem).data('transform');
@@ -140,34 +140,37 @@
     }
   };
 
-  // ## 'transformOrigin' CSS hook
-  // Allows the use for `transformOrigin` to define where scaling and rotation
-  // is pivoted.
-  //
-  //     $("#hello").css({ transformOrigin: '0 0' });
-  //
-  $.cssHooks.transformOrigin = {
-    get: function(elem) {
-      return elem.style[support.transformOrigin];
-    },
-    set: function(elem, value) {
-      elem.style[support.transformOrigin] = value;
-    }
-  };
+  // jQuery 1.8 unprefixes for us automatically.
+  if($.fn.jquery < "1.8.0") {
+    // ## 'transformOrigin' CSS hook
+    // Allows the use for `transformOrigin` to define where scaling and rotation
+    // is pivoted.
+    //
+    //     $("#hello").css({ transformOrigin: '0 0' });
+    //
+    $.cssHooks.transformOrigin = {
+      get: function(elem) {
+        return elem.style[support.transformOrigin];
+      },
+      set: function(elem, value) {
+        elem.style[support.transformOrigin] = value;
+      }
+    };
 
-  // ## 'transition' CSS hook
-  // Allows you to use the `transition` property in CSS.
-  //
-  //     $("#hello").css({ transition: 'all 0 ease 0' }); 
-  //
-  $.cssHooks.transition = {
-    get: function(elem) {
-      return elem.style[support.transition];
-    },
-    set: function(elem, value) {
-      elem.style[support.transition] = value;
-    }
-  };
+    // ## 'transition' CSS hook
+    // Allows you to use the `transition` property in CSS.
+    //
+    //     $("#hello").css({ transition: 'all 0 ease 0' });
+    //
+    $.cssHooks.transition = {
+      get: function(elem) {
+        return elem.style[support.transition];
+      },
+      set: function(elem, value) {
+        elem.style[support.transition] = value;
+      }
+    };
+  }
 
   // ## Other CSS hooks
   // Allows you to rotate, scale and translate.
@@ -411,13 +414,14 @@
   function getProperties(props) {
     var re = [];
 
-    $.each(props, function(key) {
-      key = $.camelCase(key); // Convert "text-align" => "textAlign"
-      key = $.transit.propertyMap[key] || key;
-      key = uncamel(key); // Convert back to dasherized
-
+    for(var key in props) {
+      if(props.hasOwnProperty(key)) {
+        key = $.camelCase(key); // Convert "text-align" => "textAlign"
+        key = $.transit.propertyMap[key] || key;
+        key = uncamel(key); // Convert back to dasherized
+      }
       if ($.inArray(key, re) === -1) { re.push(key); }
-    });
+    }
 
     return re;
   }
@@ -444,9 +448,10 @@
     // For more properties, add them this way:
     // "margin 200ms ease, padding 200ms ease, ..."
     var transitions = [];
-    $.each(props, function(i, name) {
+    for(var i = 0; i < props.length; i++) {
+      var name = props[i];
       transitions.push(name + ' ' + attribs);
-    });
+    }
 
     return transitions.join(', ');
   }
@@ -557,9 +562,10 @@
         if (bound) { self.unbind(transitionEnd, cb); }
 
         if (i > 0) {
-          self.each(function() {
-            this.style[support.transition] = (oldTransitions[this] || null);
-          });
+          for(var e = 0; e < self.length; e++) {
+            var elem = self[e];
+            elem.style[support.transition] = (oldTransitions[elem] || null);
+          }
         }
 
         if (typeof callback === 'function') { callback.apply(self); }
@@ -576,13 +582,14 @@
       }
 
       // Apply transitions.
-      self.each(function() {
+      for(var e = 0; e < self.length; e++) {
+        var elem = self[e];
         if (i > 0) {
-          this.style[support.transition] = transitionValue;
+          elem.style[support.transition] = transitionValue;
         }
-        $(this).css(properties);
-      });
-    };
+        $(elem).css(properties);
+      }
+    }
 
     // Defer running. This allows the browser to paint any pending CSS it hasn't
     // painted yet before doing the transitions.
@@ -616,10 +623,10 @@
       },
 
       set: function(elem, value) {
-        var t = $(elem).css('transit:transform') || new Transform();
+        var $elem = $(elem)
+        var t = $elem.css('transit:transform') || new Transform();
         t.setFromString(prop, value);
-
-        $(elem).css({ transform: t });
+        $elem.css("transit:transform", t)
       }
     };
   }

--- a/test/jquery.1.7.test.html
+++ b/test/jquery.1.7.test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+    <script src="../jquery.transit.js"></script>
+    <style>
+      .transformer {
+        width: 100px;
+        height: 100px;
+        background: #abc;
+        -webkit-transform: translateX(50px) scale(0.5);
+        -moz-transform: translateX(50px) scale(0.5);
+        -ms-transform: translateX(50px) scale(0.5);
+      }
+    </style>
+
+    <script>
+      $(function() {
+        $(".transformer").on("click", function() {
+          var $this = $(this);
+          $this.
+            html("Running").
+            transition({x: 100, y: 100, scale: 2.0, backgroundColor: '#f00'}).
+            transition({x: 200, y: 200, scale: 0.2, backgroundColor: '#0f0'}, function() {
+              $this.css({transform: ''}).html("Finished!")
+            })
+        })
+      })
+    </script>
+  </head>
+  <body>
+    <div class="transformer">
+    </div>
+  </body>
+</html>

--- a/test/jquery.1.8.test.html
+++ b/test/jquery.1.8.test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js"></script>
+    <script src="../jquery.transit.js"></script>
+    <style>
+      .transformer {
+        width: 100px;
+        height: 100px;
+        background: #abc;
+        -webkit-transform: translateX(50px) scale(0.5);
+        -moz-transform: translateX(50px) scale(0.5);
+        -ms-transform: translateX(50px) scale(0.5);
+      }
+    </style>
+
+    <script>
+      $(function() {
+        $(".transformer").on("click", function() {
+          var $this = $(this);
+          $this.
+            html("Running").
+            transition({x: 100, y: 100, scale: 2.0, backgroundColor: '#f00'}).
+            transition({x: 200, y: 200, scale: 0.2, backgroundColor: '#0f0'}, function() {
+              $this.css({transform: ''}).html("Finished!")
+            })
+        })
+      })
+    </script>
+  </head>
+  <body>
+    <div class="transformer">
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
I was unable to load jQuery.Transit in my Require.js environment. I wrapped the plugin in a method provided by the UMD spec to optionally allow it to export its namespace in an AMD when available. More info about the code update here: https://github.com/umdjs/umd
