### PR TITLE
Fixes translate(100px, undefinedpx), and transition transform

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -609,13 +609,8 @@
     // Defer running. This allows the browser to paint any pending CSS it hasn't
     // painted yet before doing the transitions.
     var deferredRun = function(next) {
-      var i = 0;
-
-      // Durations that are too slow will get transitions mixed up.
-      // (Tested on Mac/FF 7.0.1)
-      if ((support.transition === 'MozTransition') && (i < 25)) { i = 25; }
-
-      window.setTimeout(function() { run(next); }, i);
+      this.offsetWidth; // force a repaint
+      run(next);
     };
 
     // Use jQuery's fx queue.


### PR DESCRIPTION
2 minor bug fixes:

1)
css('translate' ,100) was setting 
-moz-translate(100px, undefinedpx), 
instead of 
-moz-translate(100px, 0px)
causing css asignment to fail.

Problem was strict equality with null. Added check for undefined fixes the bug.

2)
css('transition', 'transform 0.2s') was setting
-moz-transition transform 0.2s
instead of
-moz-transition MozTransform 0.2s
causing transition not to run at all.

Fix is to use prefixed properties as transition arguments. 

Love the library! Thanks.
