### PR TITLE
fixes issue #82

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -106,7 +106,7 @@
   $.cssHooks.transform = {
     // The getter returns a `Transform` object.
     get: function(elem) {
-      return $(elem).data('transform');
+      return $(elem).data('transform') || new Transform();
     },
 
     // The setter accepts a `Transform` object or a string.
@@ -603,12 +603,12 @@
 
     $.cssHooks[prop] = {
       get: function(elem) {
-        var t = $(elem).css('transform') || new Transform();
+        var t = $(elem).css('transform');
         return t.get(prop);
       },
 
       set: function(elem, value) {
-        var t = $(elem).css('transform') || new Transform();
+        var t = $(elem).css('transform');
         t.setFromString(prop, value);
 
         $(elem).css({ transform: t });


### PR DESCRIPTION
FF16 starts to support the non-prefix version of transformation, so $(elem).css("transform") will return a matrix, I change the css hook for transform and let it override the default behavior.
And It works for me.
Seems that IE10 also has the same problem, but no chance to test against it.

index 3ebae61..830aeb2 100644
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -106,7 +106,7 @@
   $.cssHooks.transform = {
     // The getter returns a `Transform` object.
     get: function(elem) {
-      return $(elem).data('transform');
- ```
   return $(elem).data('transform') || new Transform();
  ```
  
   },
  
   // The setter accepts a `Transform` object or a string.
  @@ -603,12 +603,12 @@
  
   $.cssHooks[prop] = {
     get: function(elem) {
-        var t = $(elem).css('transform') || new Transform();
- ```
     var t = $(elem).css('transform');
   return t.get(prop);
  ```
  
     },
  
     set: function(elem, value) {
-        var t = $(elem).css('transform') || new Transform();
- ```
     var t = $(elem).css('transform');
   t.setFromString(prop, value);
  
   $(elem).css({ transform: t });
  ```
