### PR TITLE
Fixing Issue 48: Error when calling .transition() in IE 10

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -150,7 +150,7 @@
   // ## 'transition' CSS hook
   // Allows you to use the `transition` property in CSS.
   //
-  //     $("#hello").css({ transition: 'all 0 ease 0' }); 
+  //     $("#hello").css({ transition: 'all 0 ease 0' });
   //
   $.cssHooks.transition = {
     get: function(elem) {
@@ -604,11 +604,19 @@
     $.cssHooks[prop] = {
       get: function(elem) {
         var t = $(elem).css('transform') || new Transform();
+        // Issue 48: Error when calling .transition() in IE 10
+        if (typeof t === 'string') {
+            t = new Transform();
+        }
         return t.get(prop);
       },
 
       set: function(elem, value) {
         var t = $(elem).css('transform') || new Transform();
+        // Issue 48: Error when calling .transition() in IE 10
+        if (typeof t === 'string') {
+            t = new Transform();
+        }
         t.setFromString(prop, value);
 
         $(elem).css({ transform: t });


### PR DESCRIPTION
Other proposed solutions are great. This syntax is a little easier for me to read.
