### PR TITLE
Updating 'transitionEnd' to 'transitionend' for IE10 support

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -69,7 +69,7 @@
   support.transform3d     = checkTransform3dSupport();
 
   var eventNames = {
-    'transition':       'transitionEnd',
+    'transition':       'transitionend',
     'MozTransition':    'transitionend',
     'OTransition':      'oTransitionEnd',
     'WebkitTransition': 'webkitTransitionEnd',


### PR DESCRIPTION
IE10 Supports transitions, but is case sensitive with the transitionend event. Callbacks on that event will not fire unless it's specifically "transitionend."

Tested Browsers:

IE10 desktop (windows 8) & mobile (winphone 8)
Chrome (newest)
Safari 6
Mobile Safari iOS 6
