### PR TITLE
Support for translateZ

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -206,6 +206,7 @@
   // Allows you to rotate, scale and translate.
   registerCssHook('scale');
   registerCssHook('translate');
+  registerCssHook('translateZ');
   registerCssHook('rotate');
   registerCssHook('rotateX');
   registerCssHook('rotateY');
@@ -355,6 +356,11 @@
         if (y !== null && y !== undefined) { this._translateY = unit(y, 'px'); }
 
         this.translate = this._translateX + "," + this._translateY;
+      },
+
+      // ### translateZ
+      translateZ: function(z) {
+        this.translateZ = unit(z, 'px');
       }
     },
 
@@ -365,6 +371,10 @@
 
       y: function() {
         return this._translateY || 0;
+      },
+
+      translateZ: function() {
+        return this.translateZ || 0;
       },
 
       scale: function() {
@@ -409,6 +419,7 @@
           if ((!support.transform3d) && (
             (i === 'rotateX') ||
             (i === 'rotateY') ||
+            (i === 'translateZ') ||
             (i === 'perspective') ||
             (i === 'transformOrigin'))) { continue; }
 
@@ -556,6 +567,9 @@
     // Set defaults. (`400` duration, `ease` easing)
     if (typeof duration === 'undefined') { duration = $.fx.speeds._default; }
     if (typeof easing === 'undefined')   { easing = $.cssEase._default; }
+
+    // Disable animation
+    if ($.fx.off) { duration = 0; }
 
     duration = toMS(duration);
 


### PR DESCRIPTION
Added support for translateZ.
Started respecting $.fx.off setting ( http://api.jquery.com/jquery.fx.off/ ).

Tested in Chrome 24 as well as iOS 6.0.1
