### PR TITLE
Support for transition(properties, options) syntax. fixes #25

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -521,6 +521,15 @@
       duration = undefined;
     }
 
+    // Account for `.transition(properties, options)`.
+    if (typeof duration === 'object') {
+      easing = duration.easing;
+      delay = duration.delay || 0;
+      queue = duration.queue || true;
+      callback = duration.complete;
+      duration = duration.duration;
+    }
+
     // Account for `.transition(properties, duration, callback)`.
     if (typeof easing === 'function') {
       callback = easing;


### PR DESCRIPTION
Support for this standard syntax was missing. Now it's fixed. Your alternate syntax is left untouched.
