### PR TITLE
Add transition support for CSS 'filter' fixes issue #95

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -464,6 +464,10 @@
       key = $.transit.propertyMap[key] || $.cssProps[key] || key;
       key = uncamel(key); // Convert back to dasherized
 
+      // Get vendor specify propertie
+      if (support[key])
+        key = uncamel(support[key]);
+
       if ($.inArray(key, re) === -1) { re.push(key); }
     });
 


### PR DESCRIPTION
Added a $.cssHook for "filter" and added transition support.

The $.cssHook for "filter" should be included in jQuery, dosen't relate to jquery.transit but for now it should be ok to use it like this.

This fixes issue #95
