### PR TITLE
Adds support for "normal" fx speed.

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -685,7 +685,7 @@
     var i = duration;
 
     // Allow for string durations like 'fast'.
-    if ($.fx.speeds[i]) { i = $.fx.speeds[i]; }
+    if (typeof i === 'string') { i = $.fx.speeds[i] || $.fx.speeds._default; }
 
     return unit(i, 'ms');
   }


### PR DESCRIPTION
jQuery supports three string speeds: "fast", "slow" and "normal" (uses $.fx.speeds._default). This patch adds support for "normal" (previously that resulted in no animation).
