### PR TITLE
Fixes for broken duration

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -689,14 +689,16 @@
   // ### toMS(duration)
   // Converts given `duration` to a millisecond string.
   //
-  //     toMS('fast')   //=> '400ms'
-  //     toMS(10)       //=> '10ms'
+  // toMS('fast') => $.fx.speeds[i] => "200ms"
+  // toMS('normal') //=> $.fx.speeds._default => "400ms"
+  // toMS(10) //=> '10ms'
+  // toMS('100ms') //=> '100ms'  
   //
   function toMS(duration) {
     var i = duration;
 
-    // Allow for string durations like 'fast'.
-    if (typeof i === NaN) { i = $.fx.speeds[i] || $.fx.speeds._default; }
+    // Allow string durations like 'fast' and 'slow', without overriding numeric values.
+    if (typeof i === 'string' && (!i.match(/^[\-0-9\.]+/))) { i = $.fx.speeds[i] || $.fx.speeds._default; }
 
     return unit(i, 'ms');
   }


### PR DESCRIPTION
Duration property is currently broken in two ways:

1) toMS() is called twice and the checking for a string means anything is always set back to  to $.fx.speeds._default  e.g.  {duration: 1500}  , 1500 > "1500ms" > $.fx.speeds._default

2)  For code like
$("#box).transition({ x:"+=100px", duration:1500  })
.transition({ x: "-=100px", duration:1500 })
the second duration reverts to default because of deleting the property.duration property the first time around. Deep cloning properties works around it.
