### PR TITLE
Fix issue with child completions bubbling up to parent

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -596,8 +596,14 @@
     var run = function(nextCall) {
       var bound = false;
 
-      // Prepare the callback.
-      var cb = function() {
+      // Prepare the callback. If using transitionEnd, event will be the event object.
+      // When using the setTimeout method, event will be undefined.
+      var cb = function(event) {
+        
+        if (event && (event.currentTarget !== event.target)) {
+          return;
+        }
+        
         if (bound) { self.unbind(transitionEnd, cb); }
 
         if (i > 0) {


### PR DESCRIPTION
When using transitionEnd, if you kick off a transition of a child and a parent and the child transition finishes before the parent, the event bubbles up and tells the parent to end prematurely.

By checking whether or not the event target is the current target, you can determine whether or not the event is occurring on the element you actually care about.
