### PR TITLE
Modify for allow different duration, easing and delay for each attribute...

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -487,17 +487,29 @@
     var props = getProperties(properties);
 
     // Account for aliases (`in` => `ease-in`).
-    if ($.cssEase[easing]) { easing = $.cssEase[easing]; }
+    //if ($.cssEase[easing]) { easing = $.cssEase[easing]; }
 
     // Build the duration/easing/delay attributes for it.
-    var attribs = '' + toMS(duration) + ' ' + easing;
-    if (parseInt(delay, 10) > 0) { attribs += ' ' + toMS(delay); }
+    //var attribs = '' + toMS(duration) + ' ' + easing;
+    //if (parseInt(delay, 10) > 0) { attribs += ' ' + toMS(delay); }
 
     // For more properties, add them this way:
     // "margin 200ms ease, padding 200ms ease, ..."
-    var transitions = [];
+	
+	var is_duration_array = typeof duration === 'object' ? true : false;
+	var is_easing_array = typeof easing === 'object' ? true : false;
+	var is_delay_array = typeof delay === 'object' ? true : false;
+	
+    var transitions = [], attr_duration = '', attr_easing = '', attr_delay = '';
     $.each(props, function(i, name) {
-      transitions.push(name + ' ' + attribs);
+		if(duration) attr_duration = toMS(is_duration_array ? duration[i] : duration);
+		if(easing){
+			attr_easing = is_easing_array ? easing[i] : easing;
+			if($.cssEase[attr_easing]) attr_easing = $.cssEase[attr_easing];
+		}
+		if(delay) attr_delay = toMS(is_delay_array ? delay[i] : delay);
+		
+      	transitions.push(name + ' ' + attr_duration + ' ' + attr_easing + ' ' + attr_delay);
     });
 
     return transitions.join(', ');
@@ -587,7 +599,7 @@
     if (typeof duration === 'undefined') { duration = $.fx.speeds._default; }
     if (typeof easing === 'undefined')   { easing = $.cssEase._default; }
 
-    duration = toMS(duration);
+    //duration = toMS(duration);
 
     // Build the `transition` property.
     var transitionValue = getTransition(theseProperties, duration, easing, delay);


### PR DESCRIPTION
Example: 

```
    $("#hover").transition({
        opacity: 0.5,
        scale: 0.3,
        duration: [250, 500],
        easing: 'in',
        delay: [500, 200]
    });
```

opacity transition now has duration 250, easing in and delay 500
scale transition now has duration 500, easing in and delay 200
