### PR TITLE
Syntax for complete callback. Complete should be in second param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ $("#box").transition({ opacity: 0.1, scale: 0.3 }, function() {..});            
 $("#box").transition({ opacity: 0.1, scale: 0.3 }, 500, 'in', function() {..});  // everything
 ```
 
-You can also pass *duration* and *easing* and *complete* as values in `options`, just like in `$.fn.animate()`.
+You can also pass *duration* and *easing* and *complete* as values in a second parameter, just like in `$.fn.animate()`.
 
 ``` javascript
 $("#box").transition({
-  opacity: 0.1, scale: 0.3,
+  opacity: 0.1, 
+  scale: 0.3,
+}, {
   duration: 500,
   easing: 'in',
   complete: function() { /* ... */ }

--- a/test/index.html
+++ b/test/index.html
@@ -138,9 +138,13 @@
     });
 
     test('as "complete"', function($box) {
-      $box.transition({
-        rotate: 45,
-        complete: function() { $box.html('OK'); }
+      $box.transition(
+        {
+          rotate: 45
+        },
+        { 
+          complete: function() { $box.html('OK'); 
+        }
       });
     });
 


### PR DESCRIPTION
The 'as "complete"' test is broken in both IE and Chrome as the complete callback is fired before the animation ends. This is fixed by passing complete as a part of the second parameter object.

This is also how jQuery animate does it, as transition() follows its syntax:
http://api.jquery.com/animate/

 Passing a complete callback inside the first object does not work in $.fn.animate:
http://codepen.io/anon/pen/fErzb
