### PR TITLE
Update default useTransitionEnd to true

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -28,7 +28,7 @@
     enabled: true,
 
     // Set this to false if you don't want to use the transition end property.
-    useTransitionEnd: false
+    useTransitionEnd: true
   };
 
   var div = document.createElement('div');


### PR DESCRIPTION
I've been using this plugin in many projects and in almost every project the animations are much smoother when useTransitionEnd is on true. Especially when a jQuery .stop() is used.
