### PR TITLE
Add option to use 3D transforms in Chrome

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -28,7 +28,10 @@
     enabled: true,
 
     // Set this to false if you don't want to use the transition end property.
-    useTransitionEnd: false
+    useTransitionEnd: false,
+
+    // Set this to true to force the use of 3d versions of transforms in Chrome
+    use3dChrome: false
   };
 
   var div = document.createElement('div');
@@ -152,7 +155,8 @@
       // forcing Chrome to not use the 3d transforms as well.  Not sure if
       // translate is affectede, but not risking it.  Detection code from
       // http://davidwalsh.name/detecting-google-chrome-javascript
-      if (support.transform === 'WebkitTransform' && !isChrome) {
+      if (support.transform === 'WebkitTransform' &&
+          (!isChrome || $.transit.use3dChrome)) {
         elem.style[support.transform] = value.toString(true);
       } else {
         elem.style[support.transform] = value.toString();


### PR DESCRIPTION
For a project I'm working on it's very noticeably slower when using
transform instead of transform3d, and I would like to have the option to
decide for myself to use 3d transforms.

I've set the option to be default off to match the current default behavior.
