### PR TITLE
fix modification of original property object

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -659,7 +659,7 @@
         if (i > 0) {
           this.style[support.transition] = transitionValue;
         }
-        $(this).css(properties);
+        $(this).css(theseProperties);
       });
     };
 


### PR DESCRIPTION
This is a little fix for the problem @Wargasmic had in #204. In short: After the transition the original property object is changed, especially the scale property. This happens because the original `properties` is used for setting the css, not the cloned `theseProperties`.

Tested in:
Firefox 25
Chrome 35
Safari 7.05

All on Mac OS X.
