### PR TITLE
Add a use3dTransform option to disable 3d transforms at will.

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -40,6 +40,9 @@
     // Will simply transition "instantly" if false
     enabled: true,
 
+	 // Use 3d transform
+	 use3dTransform: true,
+
     // Set this to false if you don't want to use the transition end property.
     useTransitionEnd: false
   };
@@ -166,7 +169,7 @@
       // translate is affectede, but not risking it.  Detection code from
       // http://davidwalsh.name/detecting-google-chrome-javascript
       if (support.transform === 'WebkitTransform' && !isChrome) {
-        elem.style[support.transform] = value.toString(true);
+        elem.style[support.transform] = value.toString($.transit.use3dTransform);
       } else {
         elem.style[support.transform] = value.toString();
       }
@@ -434,8 +437,9 @@
 
       for (var i in this) {
         if (this.hasOwnProperty(i)) {
-          // Don't use 3D transformations if the browser can't support it.
-          if ((!support.transform3d) && (
+          // Don't use 3D transformations if the browser can't support it
+	       // or if the use3dTransform option is false.
+          if ((!support.transform3d || !$.transit.use3dTransform) && (
             (i === 'rotateX') ||
             (i === 'rotateY') ||
             (i === 'perspective') ||

--- a/test/index.html
+++ b/test/index.html
@@ -52,6 +52,8 @@
 
   <div class='tests'></div>
   <script>
+	 // $.transit.use3dTransform = false;
+
     group('Transformations');
 
     test('Translation', function($box) { $box.transition({ x: 20, y: 20 }); });

--- a/test/index.html
+++ b/test/index.html
@@ -52,7 +52,7 @@
 
   <div class='tests'></div>
   <script>
-	 // $.transit.use3dTransform = false;
+    // $.transit.use3dTransform = false;
 
     group('Transformations');
 


### PR DESCRIPTION
Hi,

I find it useful to add a property directly to the transit plugin that allow you to enable / disable 3d transforms at will.
It's true that it's a boost to old ios (4-), but the fact is that using it on recents ios safari would cause text inside 3d transformed elements to be blurry.

I've added a commented line on the test file that allow you to quickly test on ios safari the feature.
