### PR TITLE
A small bugfix for minified version of this plugin

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -666,7 +666,7 @@
     // Defer running. This allows the browser to paint any pending CSS it hasn't
     // painted yet before doing the transitions.
     var deferredRun = function(next) {
-        this.offsetWidth; // force a repaint
+        this.offsetWidth = this.offsetWidth; // force a repaint
         run(next);
     };
 


### PR DESCRIPTION
Minified versions of jquery.transit can be prone to having this.offsetWidth line removed from deferredRun function during optimization stage. This leads to a severe bug of transitions not showing in minified versions.

Fixed by adding lhs to this.offsetWidth expression.
