### PR TITLE
Fix filter property issue for Firefox

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -78,6 +78,9 @@
   support.transform       = getVendorPropertyName('transform');
   support.transformOrigin = getVendorPropertyName('transformOrigin');
   support.filter          = getVendorPropertyName('Filter');
+  if (!support.filter) { // Firefox requires a lower-case f
+    support.filter            = getVendorPropertyName('filter');
+  }
   support.transform3d     = checkTransform3dSupport();
 
   var eventNames = {


### PR DESCRIPTION
It appears that Firefox requires the 'filter' property to have a lower-case 'f'.
Chrome however requires an upper-case 'F'.

This commit adds a fallback case for Firefox that attmepts to use detect the 'filter' property if the initial check fails.
