### PR TITLE
Add support for *skew*.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $("#box").css({ translate: [60,30] });      // Move right and down
 $("#box").css({ rotate: '30deg' });         // Rotate clockwise
 $("#box").css({ scale: 2 });                // Scale up 2x (200%)
 $("#box").css({ scale: [2, 1.5] });         // Scale horiz and vertical
+$("#box").css({ skew: '45deg, 45deg' });    // Skew in both directions at the same time
 $("#box").css({ skewX: '30deg' });          // Skew horizontally
 $("#box").css({ skewY: '30deg' });          // Skew vertical
 $("#box").css({ perspective: 100, rotateX: 30 }); // Webkit 3d rotation

--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -240,6 +240,7 @@
   registerCssHook('rotateY');
   registerCssHook('rotate3d');
   registerCssHook('perspective');
+  registerCssHook('skew');
   registerCssHook('skewX');
   registerCssHook('skewY');
   registerCssHook('x', true);
@@ -341,6 +342,11 @@
       scale: function(x, y) {
         if (y === undefined) { y = x; }
         this.scale = x + "," + y;
+      },
+
+      // ### skew
+      skew: function(x, y) {
+        this.skew = unit(x, 'deg') + "," + unit(y, 'deg');
       },
 
       // ### skewX + skewY


### PR DESCRIPTION
This PR adds support for *skew* transform, in no more than 10 lines of code.

The transforms *skewX* and *skewY* were already supported in current version. However, *skew* cannot be replaced with them (perhaps there is a way to make such replacement but seems hard to do so).

We may try the following snippets, which lead to different styles:

- `transform skew(45deg, 45deg)`
- `transform skewX(45deg) skewY(45deg)`
- `transform skewY(45deg) skewX(45deg)`
