### PR TITLE
docs: Fix simple typo, perspectvie -> perspective

### DIFF
--- a/jquery.transit.js
+++ b/jquery.transit.js
@@ -352,7 +352,7 @@
         this.skewY = unit(y, 'deg');
       },
 
-      // ### perspectvie
+      // ### perspective
       perspective: function(dist) {
         this.perspective = unit(dist, 'px');
       },


### PR DESCRIPTION
There is a small typo in jquery.transit.js.

Should read `perspective` rather than `perspectvie`.

